### PR TITLE
added getTables() for a more flexible public api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 selfup-rejs/*
+/coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+selfup-rejs/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-selfup-rejs/*
 /coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+selfup-rejs/*
 /coverage

--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 **File based database! Built for developer freedom.**
 
-Installation: `npm install selfup-rejs --save`
+**Installation:**
 
-Load package:
+`npm install selfup-rejs --save`
+
+**Ensure your data is safe and not in version control:**
+
+`echo 'selfup-rejs/*' >> .gitignore`
+
+**Load package:**
 
     const selfupRejs = require('selfup-rejs')
     const rejs = new selfupRejs

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@
 
 ### How to Use:
 
-Using RESTful verbs to help explain from a high level what is happening.
+* Using RESTful verbs to help explain from a high level what is happening.
+* This is not a server.
+* This is a database that writes and reads files on the server.
 
-This is not a server.
-
-This is a database that writes and reads files on the server.
 
 * (POST)   Create a table: `rejs.createTable('tablename')`
 * (POST)   Add data to table: `rejs.newData('tablename', dataObject)`
@@ -32,11 +31,13 @@ This is a database that writes and reads files on the server.
 * (GET)    Find by ID: `rejs.findId('tablename', 'id')`
 * (GET)    Where/Select: `rejs.where('tablename', 'any value in a flat object')`
 
-**Video on how to use selfup-rejs:** [Link to Youtube Vid](https://www.youtube.com/watch?v=dVTePMkw9EE&feature=youtu.be&a)
+### Video on how to use selfup-rejs:
+
+[Link to Youtube Vid](https://www.youtube.com/watch?v=dVTePMkw9EE&feature=youtu.be&a)
 
 ### Potential use Cases:
 
-#### JohnnyFive/NodeBots
+#### JohnnyFive/NodeBots/IoT
 
 * Store temperature data over time
 * Store how many times a door has been opened

--- a/README.md
+++ b/README.md
@@ -56,11 +56,18 @@
 
 To get 100% coverage:
 
+If the `selfup-rejs` folder is in your directory:
+
 ```
 npm install
 rm -rf selfup-rejs
-./node_modules/.bin/istanbul cover _mocha
 ```
+
+Then you can run:
+
+`./node_modules/.bin/istanbul cover _mocha`
+
+Now the selfup-rejs folder will be in your directory again!
 
 To run tests without coverage:
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@
 
 100% according to istanbul
 
-![](http://i.imgur.com/doE5Iex.png)
-
 To get 100% coverage:
 
 ```
@@ -69,3 +67,7 @@ rm -rf selfup-rejs
 To run tests without coverage:
 
 `npm test`
+
+![](http://i.imgur.com/doE5Iex.png)
+
+![](http://i.imgur.com/9E969Dp.png)

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@
 
 ### Test Coverage
 
-100% according to istanbul
-
 To get 100% coverage:
 
 ```
@@ -67,6 +65,8 @@ rm -rf selfup-rejs
 To run tests without coverage:
 
 `npm test`
+
+Pictures of coverage since I gitignored the coverage folder:
 
 ![](http://i.imgur.com/doE5Iex.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Selfup - Rejs
 
-**File based database! Built for developer freedom.**
+### File based database! Built for developer freedom. Geared for NodeBots and IoT
 
 **Installation:**
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 ### Test Coverage
 
-To get 100% coverage:
+#### To get 100% coverage:
 
 If the `selfup-rejs` folder is in your directory:
 
@@ -69,7 +69,7 @@ Then you can run:
 
 Now the selfup-rejs folder will be in your directory again!
 
-To run tests without coverage:
+#### To run tests without coverage:
 
 `npm test`
 

--- a/README.md
+++ b/README.md
@@ -51,3 +51,21 @@
 
 * Use it as a small DB for a low volume production app
 * Use it to get quickly set up, and then move on to Mongo/Postgres once your app is mature and MVP is proven
+
+### Test Coverage
+
+100% according to istanbul
+
+![](http://i.imgur.com/doE5Iex.png)
+
+To get 100% coverage:
+
+```
+npm install
+rm -rf selfup-rejs
+./node_modules/.bin/istanbul cover _mocha
+```
+
+To run tests without coverage:
+
+`npm test`

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Event based, key value store on the file system. Basic server side db in js for node developers. Geared towards NodeBots/IoT.",
   "main": "re.js",
   "scripts": {
+    "pre-install": "rm -rf selfup-rejs",
     "test": "mocha"
   },
   "keywords": [
@@ -32,7 +33,8 @@
     "lodash": "^4.9.0"
   },
   "devDependencies": {
-    "mocha": "^2.4.5",
-    "chai": "^3.5.0"
+    "chai": "^3.5.0",
+    "istanbul": "^0.4.3",
+    "mocha": "^2.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "selfup-rejs",
   "version": "1.0.16",
-  "description": "Event based, key value store on the file system. Basic server side db in js for node developers.",
+  "description": "Event based, key value store on the file system. Basic server side db in js for node developers. Geared towards NodeBots/IoT.",
   "main": "re.js",
   "scripts": {
     "test": "mocha"

--- a/re.js
+++ b/re.js
@@ -52,18 +52,12 @@ class Rejs {
     return _.filter(records, (record) => _.includes(record, prop))
   }
 
-  doubleGet(firstTableName, secondTableName) {
-    let doubleTable = []
-    doubleTable.push(this.getTable(firstTableName))
-    doubleTable.push(this.getTable(secondTableName))
-    return doubleTable
-  }
-
-  quadGet(firstTableName, secondTableName, thirdTableName, fourthTableName) {
-    let quadTable = []
-    quadTable.push(this.doubleGet(firstTableName, secondTableName))
-    quadTable.push(this.doubleGet(thirdTableName, fourthTableName))
-    return _.flatten(quadTable)
+  getTables(tableNames) {
+    let tables = []
+    for (let val of tableNames) {
+      tables.push(this.getTable(val))
+    }
+    return tables
   }
 
   // private

--- a/re.js
+++ b/re.js
@@ -54,8 +54,8 @@ class Rejs {
 
   getTables() {
     let tables = []
-    for (let val of Array.from(arguments)) {
-      tables.push(this.getTable(val))
+    for (let table of Array.from(arguments)) {
+      tables.push(this.getTable(table))
     }
     return tables
   }

--- a/re.js
+++ b/re.js
@@ -52,9 +52,9 @@ class Rejs {
     return _.filter(records, (record) => _.includes(record, prop))
   }
 
-  getTables(tableNames) {
+  getTables() {
     let tables = []
-    for (let val of tableNames) {
+    for (let val of Array.from(arguments)) {
       tables.push(this.getTable(val))
     }
     return tables

--- a/re.js
+++ b/re.js
@@ -52,6 +52,20 @@ class Rejs {
     return _.filter(records, (record) => _.includes(record, prop))
   }
 
+  doubleGet(firstTableName, secondTableName) {
+    let doubleTable = []
+    doubleTable.push(this.getTable(firstTableName))
+    doubleTable.push(this.getTable(secondTableName))
+    return doubleTable
+  }
+
+  quadGet(firstTableName, secondTableName, thirdTableName, fourthTableName) {
+    let quadTable = []
+    quadTable.push(this.doubleGet(firstTableName, secondTableName))
+    quadTable.push(this.doubleGet(thirdTableName, fourthTableName))
+    return _.flatten(quadTable)
+  }
+
   // private
   [_replaceTable](tableName, data) {
     fs.writeFileSync(`./selfup-rejs/${tableName}`, JSON.stringify(data))

--- a/re.js
+++ b/re.js
@@ -53,11 +53,7 @@ class Rejs {
   }
 
   getTables() {
-    let tables = []
-    for (let table of Array.from(arguments)) {
-      tables.push(this.getTable(table))
-    }
-    return tables
+    return Array.from(arguments).map(table => this.getTable(table))
   }
 
   // private

--- a/re.js
+++ b/re.js
@@ -11,7 +11,7 @@ const _initialData  = Symbol('initialData')
 class Rejs {
   constructor() {
     if (fs.existsSync("selfup-rejs")) return
-    fs.mkdirSync("selfup-rejs", err => { if (err) console.log(err) })
+    fs.mkdirSync("selfup-rejs")
   }
 
   // public

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -89,6 +89,28 @@ describe('Rejs', function() {
       })
     })
 
+    describe('getTables: three', function() {
+      it('returns an array of four tables', function() {
+        this.rejs.createTable('firstTable')
+        this.rejs.createTable('secondTable')
+        this.rejs.createTable('thirdTable')
+        this.rejs.createTable('fourthTable')
+
+        const expected = [
+          {'0': { table: 'firstTable', nextId: 1 }},
+          {'0': { table: 'secondTable', nextId: 1 }},
+          {'0': { table: 'thirdTable', nextId: 1 }}
+        ]
+        const tbls = this.rejs.getTables('firstTable', 'secondTable', 'thirdTable')
+
+        assert.deepEqual(expected, tbls)
+
+        this.rejs.dropTable('firstTable')
+        this.rejs.dropTable('secondTable')
+        this.rejs.dropTable('thirdTable')
+      })
+    })
+
     describe('getTables: four', function() {
       it('returns an array of four tables', function() {
         this.rejs.createTable('firstTable')

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -8,38 +8,38 @@ describe('Rejs', function() {
       this.rejs = new r
       this.rejs.createTable('testOne')
     })
-  
+
     afterEach(function() {
       this.rejs.dropTable('testOne')
     })
-    
+
     describe('getTable and newData', function() {
       it('appends new data and returns all the appended data from the table', function() {
         this.rejs.newData('testOne', {test: "test data 1"})
         this.rejs.newData('testOne', {test: "test data 2"})
-  
+
         const expected = {
           '0': { table: 'testOne', nextId: 3 },
           '1': { test: 'test data 1' },
           '2': { test: 'test data 2' },
         }
-  
+
         assert.deepEqual(expected, this.rejs.getTable('testOne'))
       })
     })
-    
+
      describe('where', function() {
       it('selects records that have a matching key', function() {
         this.rejs.newData('testOne', {test: "test data 1"})
         this.rejs.newData('testOne', {test: "test data 2"})
         this.rejs.newData('testOne', {test: "test data 1"})
         this.rejs.newData('testOne', {test: "test data 4"})
-  
+
         const expected = [{test: 'test data 1'}, {test: 'test data 1'}]
         assert.deepEqual(expected, this.rejs.where('testOne', 'test data 1'))
       })
     })
-  
+
     describe('findId', function() {
       it('returns the matching record if one exists', function() {
         this.rejs.newData('testOne', {test: "test data 1"})
@@ -49,7 +49,7 @@ describe('Rejs', function() {
         assert.equal(null,                      this.rejs.findId('testOne', '3'))
       })
     })
-  
+
     describe('deleteById', function() {
       it('deletes the correct object by ID in the correct table', function() {
         this.rejs.newData('testOne', {test: "test data 1"})
@@ -58,7 +58,7 @@ describe('Rejs', function() {
         assert.equal(null,                      this.rejs.findId('testOne', '2'))
       })
     })
-  
+
     describe('updateTable', function() {
       it('replaces the data in a table', function() {
         this.rejs.newData('testOne',     {test: "old data"})
@@ -70,7 +70,49 @@ describe('Rejs', function() {
         assert.deepEqual(expected, this.rejs.getTable('testOne'))
       })
     })
-  
+
+    describe('doubleGet', function() {
+      it('returns an array of two tables', function() {
+        this.rejs.createTable('firstTable')
+        this.rejs.createTable('secondTable')
+
+        const expected = [
+          {'0': { table: 'firstTable', nextId: 1 }},
+          {'0': { table: 'secondTable', nextId: 1 }}
+        ]
+        const tbls = this.rejs.doubleGet('firstTable', 'secondTable')
+
+        assert.deepEqual(expected, tbls)
+
+        this.rejs.dropTable('firstTable')
+        this.rejs.dropTable('secondTable')
+      })
+    })
+
+    describe('quadGet', function() {
+      it('returns an array of four tables', function() {
+        this.rejs.createTable('firstTable')
+        this.rejs.createTable('secondTable')
+        this.rejs.createTable('thirdTable')
+        this.rejs.createTable('fourthTable')
+
+        const expected = [
+          {'0': { table: 'firstTable', nextId: 1 }},
+          {'0': { table: 'secondTable', nextId: 1 }},
+          {'0': { table: 'thirdTable', nextId: 1 }},
+          {'0': { table: 'fourthTable', nextId: 1 }}
+        ]
+        const tbls = this.rejs.quadGet('firstTable', 'secondTable', 'thirdTable', 'fourthTable')
+
+        assert.deepEqual(expected, tbls)
+
+        this.rejs.dropTable('firstTable')
+        this.rejs.dropTable('secondTable')
+        this.rejs.dropTable('thirdTable')
+        this.rejs.dropTable('fourthTable')
+      })
+    })
+
     describe('newAndGetBenchmark', function() {
     it('can append and fetch a good amount of data', function() {
       for (let i = 0; i < 10; i++) {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -71,7 +71,7 @@ describe('Rejs', function() {
       })
     })
 
-    describe('doubleGet', function() {
+    describe('getTables: two', function() {
       it('returns an array of two tables', function() {
         this.rejs.createTable('firstTable')
         this.rejs.createTable('secondTable')
@@ -80,7 +80,7 @@ describe('Rejs', function() {
           {'0': { table: 'firstTable', nextId: 1 }},
           {'0': { table: 'secondTable', nextId: 1 }}
         ]
-        const tbls = this.rejs.doubleGet('firstTable', 'secondTable')
+        const tbls = this.rejs.getTables(['firstTable', 'secondTable'])
 
         assert.deepEqual(expected, tbls)
 
@@ -89,7 +89,7 @@ describe('Rejs', function() {
       })
     })
 
-    describe('quadGet', function() {
+    describe('getTables: four', function() {
       it('returns an array of four tables', function() {
         this.rejs.createTable('firstTable')
         this.rejs.createTable('secondTable')
@@ -102,7 +102,7 @@ describe('Rejs', function() {
           {'0': { table: 'thirdTable', nextId: 1 }},
           {'0': { table: 'fourthTable', nextId: 1 }}
         ]
-        const tbls = this.rejs.quadGet('firstTable', 'secondTable', 'thirdTable', 'fourthTable')
+        const tbls = this.rejs.getTables(['firstTable', 'secondTable', 'thirdTable', 'fourthTable'])
 
         assert.deepEqual(expected, tbls)
 

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -80,7 +80,7 @@ describe('Rejs', function() {
           {'0': { table: 'firstTable', nextId: 1 }},
           {'0': { table: 'secondTable', nextId: 1 }}
         ]
-        const tbls = this.rejs.getTables(['firstTable', 'secondTable'])
+        const tbls = this.rejs.getTables('firstTable', 'secondTable')
 
         assert.deepEqual(expected, tbls)
 
@@ -102,7 +102,7 @@ describe('Rejs', function() {
           {'0': { table: 'thirdTable', nextId: 1 }},
           {'0': { table: 'fourthTable', nextId: 1 }}
         ]
-        const tbls = this.rejs.getTables(['firstTable', 'secondTable', 'thirdTable', 'fourthTable'])
+        const tbls = this.rejs.getTables('firstTable', 'secondTable', 'thirdTable', 'fourthTable')
 
         assert.deepEqual(expected, tbls)
 


### PR DESCRIPTION
Can return a where equivalent of tables.

This way the public API has a bit more flexibility for developers if they need two or four tables at the same time.
